### PR TITLE
Using raft specializations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,7 @@ if(WITH_RAFT)
   include(rapids-find)
 
   rapids_cpm_init()
-  set(RAPIDS_VERSION 23.02)
+  set(RAPIDS_VERSION 23.04)
   include(cmake/libs/libraft.cmake)
 
   set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-extended-lambda --expt-relaxed-constexpr")

--- a/cmake/libs/fetch_rapids.cmake
+++ b/cmake/libs/fetch_rapids.cmake
@@ -11,7 +11,7 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 
-set(RAPIDS_VERSION "23.02")
+set(RAPIDS_VERSION "23.04")
 
 if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/FAISS_RAPIDS.cmake)
     file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-${RAPIDS_VERSION}/RAPIDS.cmake

--- a/cmake/libs/libraft.cmake
+++ b/cmake/libs/libraft.cmake
@@ -12,8 +12,8 @@
 # the License.
 
 set(RAFT_VERSION "${RAPIDS_VERSION}")
-set(RAFT_FORK "rapidsai")
-set(RAFT_PINNED_TAG "branch-${RAPIDS_VERSION}")
+set(RAFT_FORK "cjnolet")
+set(RAFT_PINNED_TAG "imp-2304-specialize_ann_int64_t")
 
 function(find_and_configure_raft)
     set(oneValueArgs VERSION FORK PINNED_TAG)

--- a/cmake/libs/libraft.cmake
+++ b/cmake/libs/libraft.cmake
@@ -27,7 +27,7 @@ function(find_and_configure_raft)
             GLOBAL_TARGETS      raft::raft
             BUILD_EXPORT_SET    faiss-exports
             INSTALL_EXPORT_SET  faiss-exports
-            COMPONENTS "distance nn"
+            COMPONENTS "distance"
             CPM_ARGS
             GIT_REPOSITORY https://github.com/${PKG_FORK}/raft.git
             GIT_TAG        ${PKG_PINNED_TAG}
@@ -36,6 +36,7 @@ function(find_and_configure_raft)
             "BUILD_TESTS OFF"
             "BUILD_BENCH OFF"
             "RAFT_COMPILE_LIBRARIES OFF"
+            "RAFT_COMPILE_DIST_LIBRARY ON"
             "RAFT_COMPILE_NN_LIBRARY OFF"
             "RAFT_USE_FAISS_STATIC OFF" # Turn this on to build FAISS into your binary
             "RAFT_ENABLE_NN_DEPENDENCIES OFF"

--- a/src/index/ivf_raft/ivf_pq_raft.cu
+++ b/src/index/ivf_raft/ivf_pq_raft.cu
@@ -14,6 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+
+// Don't re-compile IVF PQ specializations
+#include <raft/neighbors/specializations/ivf_pq.cuh>
+
+
 #include "ivf_raft.cuh"
 #include "knowhere/factory.h"
 #include "knowhere/index_node_thread_pool_wrapper.h"

--- a/src/index/ivf_raft/ivf_raft.cuh
+++ b/src/index/ivf_raft/ivf_raft.cuh
@@ -39,8 +39,8 @@
 namespace knowhere {
 
 namespace detail {
-using raft_ivf_flat_index = raft::neighbors::ivf_flat::index<float, std::uint64_t>;
-using raft_ivf_pq_index = raft::neighbors::ivf_pq::index<std::uint64_t>;
+using raft_ivf_flat_index = raft::neighbors::ivf_flat::index<float, std::int64_t>;
+using raft_ivf_pq_index = raft::neighbors::ivf_pq::index<std::int64_t>;
 
 // TODO(wphicks): Replace this with version from RAFT once merged
 struct device_setter {
@@ -183,7 +183,7 @@ class RaftIvfIndexNode : public IndexNode {
                     build_params.kmeans_n_iters = ivf_raft_cfg.kmeans_n_iters;
                     build_params.kmeans_trainset_fraction = ivf_raft_cfg.kmeans_trainset_fraction;
                     build_params.adaptive_centers = ivf_raft_cfg.adaptive_centers;
-                    gpu_index_ = raft::neighbors::ivf_flat::build<float, std::uint64_t>(*res_, build_params,
+                    gpu_index_ = raft::neighbors::ivf_flat::build<float, std::int64_t>(*res_, build_params,
                                                                                        data_gpu.data(), rows, dim);
                 } else if constexpr (std::is_same_v<detail::raft_ivf_pq_index, T>) {
                     auto build_params = raft::neighbors::ivf_pq::index_params{};
@@ -200,7 +200,7 @@ class RaftIvfIndexNode : public IndexNode {
                     }
                     build_params.codebook_kind = codebook_kind.value();
                     build_params.force_random_rotation = ivf_raft_cfg.force_random_rotation;
-                    gpu_index_ = raft::neighbors::ivf_pq::build<float, std::uint64_t>(*res_, build_params,
+                    gpu_index_ = raft::neighbors::ivf_pq::build<float, std::int64_t>(*res_, build_params,
                                                                                      data_gpu.data(), rows, dim);
                 } else {
                     static_assert(std::is_same_v<detail::raft_ivf_flat_index, T>);
@@ -234,14 +234,14 @@ class RaftIvfIndexNode : public IndexNode {
                 RAFT_CUDA_TRY(cudaMemcpyAsync(data_gpu.data(), data, data_gpu.size() * sizeof(float), cudaMemcpyDefault,
                                               stream.value()));
 
-                auto indices = rmm::device_uvector<std::uint64_t>(rows, stream);
+                auto indices = rmm::device_uvector<std::int64_t>(rows, stream);
                 thrust::sequence(thrust::device, indices.begin(), indices.end(), gpu_index_->size());
 
                 if constexpr (std::is_same_v<detail::raft_ivf_flat_index, T>) {
-                    raft::neighbors::ivf_flat::extend<float, std::uint64_t>(*res_, *gpu_index_, data_gpu.data(),
+                    raft::neighbors::ivf_flat::extend<float, std::int64_t>(*res_, *gpu_index_, data_gpu.data(),
                                                                            indices.data(), rows);
                 } else if constexpr (std::is_same_v<detail::raft_ivf_pq_index, T>) {
-                    raft::neighbors::ivf_pq::extend<float, std::uint64_t>(*res_, *gpu_index_, data_gpu.data(),
+                    raft::neighbors::ivf_pq::extend<float, std::int64_t>(*res_, *gpu_index_, data_gpu.data(),
                                                                          indices.data(), rows);
                 } else {
                     static_assert(std::is_same_v<detail::raft_ivf_flat_index, T>);
@@ -273,13 +273,13 @@ class RaftIvfIndexNode : public IndexNode {
             RAFT_CUDA_TRY(cudaMemcpyAsync(data_gpu.data(), data, data_gpu.size() * sizeof(float), cudaMemcpyDefault,
                                           stream.value()));
 
-            auto ids_gpu = rmm::device_uvector<std::uint64_t>(output_size, stream);
+            auto ids_gpu = rmm::device_uvector<std::int64_t>(output_size, stream);
             auto dis_gpu = rmm::device_uvector<float>(output_size, stream);
 
             if constexpr (std::is_same_v<detail::raft_ivf_flat_index, T>) {
                 auto search_params = raft::neighbors::ivf_flat::search_params{};
                 search_params.n_probes = ivf_raft_cfg.nprobe;
-                raft::neighbors::ivf_flat::search<float, std::uint64_t>(*res_, search_params, *gpu_index_,
+                raft::neighbors::ivf_flat::search<float, std::int64_t>(*res_, search_params, *gpu_index_,
                                                                        data_gpu.data(), rows, ivf_raft_cfg.k,
                                                                        ids_gpu.data(), dis_gpu.data());
             } else if constexpr (std::is_same_v<detail::raft_ivf_pq_index, T>) {
@@ -309,13 +309,13 @@ class RaftIvfIndexNode : public IndexNode {
                 }
                 search_params.internal_distance_dtype = internal_distance_dtype.value();
                 search_params.preferred_shmem_carveout = search_params.preferred_shmem_carveout;
-                raft::neighbors::ivf_pq::search<float, std::uint64_t>(*res_, search_params, *gpu_index_, data_gpu.data(),
+                raft::neighbors::ivf_pq::search<float, std::int64_t>(*res_, search_params, *gpu_index_, data_gpu.data(),
                                                                      rows, ivf_raft_cfg.k, ids_gpu.data(),
                                                                      dis_gpu.data());
             } else {
                 static_assert(std::is_same_v<detail::raft_ivf_flat_index, T>);
             }
-            RAFT_CUDA_TRY(cudaMemcpyAsync(ids.get(), ids_gpu.data(), ids_gpu.size() * sizeof(std::uint64_t),
+            RAFT_CUDA_TRY(cudaMemcpyAsync(ids.get(), ids_gpu.data(), ids_gpu.size() * sizeof(std::int64_t),
                                           cudaMemcpyDefault, stream.value()));
             RAFT_CUDA_TRY(cudaMemcpyAsync(dis.get(), dis_gpu.data(), dis_gpu.size() * sizeof(float), cudaMemcpyDefault,
                                           stream.value()));
@@ -360,7 +360,7 @@ class RaftIvfIndexNode : public IndexNode {
 
     virtual int64_t
     Dim() const override {
-        auto result = std::uint64_t{};
+        auto result = std::int64_t{};
         if (gpu_index_) {
             result = gpu_index_->dim();
         }
@@ -374,7 +374,7 @@ class RaftIvfIndexNode : public IndexNode {
 
     virtual int64_t
     Count() const override {
-        auto result = std::uint64_t{};
+        auto result = std::int64_t{};
         if (gpu_index_) {
             result = gpu_index_->size();
         }


### PR DESCRIPTION
This includes changes to use the raft specializations. Please note that while this does compile in its current form, we probably shouldn't use this code until we update the specializations on the RAFT side to instantiate `int64_t` instead of `uint64_t`